### PR TITLE
Pass start time to SacessWorker

### DIFF
--- a/src/pyscat/ess.py
+++ b/src/pyscat/ess.py
@@ -265,13 +265,16 @@ class ESSOptimizer:
         self,
         problem: Problem = None,
         refset: RefSet | None = None,
+        start_time: float | None = None,
     ):
         """(Re-)initialize for optimizations.
 
         Create initial refset, start timer, ... .
         """
         self._initialize()
-        self._start_time = time.time()
+        self._start_time = (
+            start_time if start_time is not None else time.time()
+        )
 
         if (refset is None and problem is None) or (
             refset is not None and problem is not None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 from pypesto.optimize import FidesOptimizer
@@ -49,7 +50,7 @@ def test_ess(rosen_problem, local_optimizer, ess_type):
         ess = SacessOptimizer(
             problem=problem,
             num_workers=12,
-            max_walltime_s=4,
+            max_walltime_s=60 / min(12, os.cpu_count()),
             sacess_loglevel=logging.DEBUG,
             ess_loglevel=logging.WARNING,
             options=SacessOptions(


### PR DESCRIPTION
Pass the start time from SacessOptimizer to SacessWorker instead of using the current time there. The setup should count towards any given walltime budget.
Mostly relevant for testing and time limits in the order of seconds.

Closes #33.