### PR TITLE
Optional inclusion of local solutions in ESSOptimizer result

### DIFF
--- a/src/pyscat/ess.py
+++ b/src/pyscat/ess.py
@@ -140,6 +140,7 @@ class ESSOptimizer:
         n_threads=None,
         max_walltime_s=None,
         result_includes_refset: bool = False,
+        result_includes_local_solutions: bool = True,
     ):
         r"""Initialize.
 
@@ -194,8 +195,10 @@ class ESSOptimizer:
             Mutually exclusive with `n_procs`.
         :param result_includes_refset:
             Whether the :meth:`minimize` result should include the final
-            RefSet, or just the local search results and the overall best
-            parameters.
+            RefSet.
+        :param result_includes_local_solutions:
+            Whether the :meth:`minimize` result should include the local search
+            results (if any).
         """
         if max_eval is None and max_walltime_s is None and max_iter is None:
             # in this case, we'd run forever
@@ -236,6 +239,7 @@ class ESSOptimizer:
             f"{self.__class__.__name__}-{id(self)}"
         )
         self._result_includes_refset = result_includes_refset
+        self._result_includes_local_solutions = result_includes_local_solutions
 
     def _initialize(self):
         """(Re-)Initialize."""
@@ -427,11 +431,12 @@ class ESSOptimizer:
         optimizer_result.update_to_full(result.problem)
         result.optimize_result.append(optimizer_result)
 
-        # save local solutions
-        for i, optimizer_result in enumerate(self.local_solutions):
-            i_result += 1
-            optimizer_result.id = f"Local solution {i}"
-            result.optimize_result.append(optimizer_result)
+        if self._result_includes_local_solutions:
+            # save local solutions
+            for i, optimizer_result in enumerate(self.local_solutions):
+                i_result += 1
+                optimizer_result.id = f"Local solution {i}"
+                result.optimize_result.append(optimizer_result)
 
         if self._result_includes_refset:
             # save refset

--- a/tests/test_ess.py
+++ b/tests/test_ess.py
@@ -32,6 +32,48 @@ def test_ess_finds_minimum(problem_info):
     )
 
 
+def test_ess_result_contains_refset(rosen_problem):
+    problem = rosen_problem
+    ess = ESSOptimizer(
+        max_walltime_s=2, dim_refset=10, result_includes_refset=True
+    )
+    res = ess.minimize(problem)
+
+    assert len(res.optimize_result) == 11
+
+    ess = ESSOptimizer(
+        max_walltime_s=2, dim_refset=10, result_includes_refset=False
+    )
+    res = ess.minimize(problem)
+
+    assert len(res.optimize_result) == 1
+
+
+def test_result_contains_local_solutions(rosen_problem):
+    problem = rosen_problem
+    ess = ESSOptimizer(
+        max_walltime_s=2,
+        dim_refset=10,
+        local_optimizer=FidesOptimizer(),
+        result_includes_local_solutions=True,
+        result_includes_refset=False,
+    )
+    res = ess.minimize(problem)
+    assert len(ess.local_solutions) > 0
+    assert len(res.optimize_result) == 1 + len(ess.local_solutions)
+
+    ess = ESSOptimizer(
+        max_walltime_s=2,
+        dim_refset=10,
+        local_optimizer=FidesOptimizer(),
+        result_includes_local_solutions=False,
+        result_includes_refset=False,
+    )
+    res = ess.minimize(problem)
+    assert len(ess.local_solutions) > 0
+    assert len(res.optimize_result) == 1
+
+
 def test_ess_multiprocess(rosen_problem):
     from fides.constants import Options as FidesOptions
 


### PR DESCRIPTION
Add `result_includes_local_solutions` argument to `ESSOptimizer.__init__` for enabling/disabling including local solutions in the result generated by  `ESSOptimizer.minimize`.