### PR TITLE
Don't create `outcmaes` directory in `SacessCmaFactory`

### DIFF
--- a/src/pyscat/sacess.py
+++ b/src/pyscat/sacess.py
@@ -1360,7 +1360,7 @@ class SacessCmaFactory:
         options: dict[str, Any] | None = None,
     ):
         if options is None:
-            options = {}
+            options = {"verbose": -10}
 
         self._options = options
 


### PR DESCRIPTION
By default, prevent `CmaOptimizer` creating the `outcmaes/` directory.