### PR TITLE
Change SacessOptimizer results, disable autosave

### DIFF
--- a/src/pyscat/ess.py
+++ b/src/pyscat/ess.py
@@ -83,7 +83,7 @@ class ESSOptimizer:
 
     :ivar history:
         History of the best values/parameters found so far.
-        (Monotonously decreasing objective values.)
+        (Monotonically decreasing objective values.)
 
 
     Hyperparameters
@@ -356,7 +356,13 @@ class ESSOptimizer:
             History object to track the best values found so far.
 
         :returns:
-            The optimization result.
+            The optimization result. Contains the overall best value found and,
+            depending on the settings, the final RefSet and local search
+            results.
+
+            Note that the number of gradient and Hessian evaluations is not
+            tracked and thus set to 0 in the result, even if a local optimizer
+            is used that performs gradient/Hessian evaluations.
         """
         self._initialize_minimize(
             problem=problem, refset=refset, history=history

--- a/src/pyscat/examples.py
+++ b/src/pyscat/examples.py
@@ -69,7 +69,7 @@ problem_info: dict[str, dict[str, Any]] = {
         "problem": problem_schwefel,
     },
     "Langermann": {
-        "global_best": -4.222073915703129,
+        "global_best": -4.222073978805628,
         "problem": problem_langermann,
     },
 }


### PR DESCRIPTION
Breaking changes in `SacessOptimizer` behavior:
* Intermediate results are only saved to file if explicitly requested (Closes #24).
* The `tmpdir` argument has been replaced by `autosave_dir`.
* The SacessOptimizer.minimize result no longer contains all local optimization results. They can be recovered from the autosave files if required.
* The SacessOptimizer.minimize contains on a single OptimizerResult representing the best point found across all workers. Its `.history` contains the monotonic history of the globally best point.